### PR TITLE
Bumps version to 0.5.0

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 0.4.0
+current_version = 0.5.0
 commit = True
 message = Bumps version to {new_version}
 tag = False


### PR DESCRIPTION
This will release the yum repo that includes salt with the python3 runtime