### PR TITLE
Creates a config to support providing versions from the salt archive

### DIFF
--- a/dev/files-repo/terraform.tfvars
+++ b/dev/files-repo/terraform.tfvars
@@ -7,10 +7,12 @@ uri_map = {
   "https://bootstrap.pypa.io/2.6/get-pip.py" = "python/pip/2.6/"
 
   # salt for windows
-  "https://repo.saltstack.com/windows/Salt-Minion-2019.2.5-Py2-AMD64-Setup.exe" = "saltstack/salt/windows/"
-  "https://repo.saltstack.com/windows/Salt-Minion-2019.2.5-Py3-AMD64-Setup.exe" = "saltstack/salt/windows/"
-  "https://repo.saltstack.com/windows/Salt-Minion-3000.3-Py2-AMD64-Setup.exe"   = "saltstack/salt/windows/"
-  "https://repo.saltstack.com/windows/Salt-Minion-3000.3-Py3-AMD64-Setup.exe"   = "saltstack/salt/windows/"
+  "https://archive.repo.saltstack.com/windows/Salt-Minion-2018.3.4-Py2-AMD64-Setup.exe" = "saltstack/salt/windows/"
+  "https://archive.repo.saltstack.com/windows/Salt-Minion-2018.3.4-Py3-AMD64-Setup.exe" = "saltstack/salt/windows/"
+  "https://repo.saltstack.com/windows/Salt-Minion-2019.2.5-Py2-AMD64-Setup.exe"         = "saltstack/salt/windows/"
+  "https://repo.saltstack.com/windows/Salt-Minion-2019.2.5-Py3-AMD64-Setup.exe"         = "saltstack/salt/windows/"
+  "https://repo.saltstack.com/windows/Salt-Minion-3000.3-Py2-AMD64-Setup.exe"           = "saltstack/salt/windows/"
+  "https://repo.saltstack.com/windows/Salt-Minion-3000.3-Py3-AMD64-Setup.exe"           = "saltstack/salt/windows/"
 }
 
 prefix = "repo/"

--- a/dev/salt-repo-archive/terraform.tfvars
+++ b/dev/salt-repo-archive/terraform.tfvars
@@ -1,0 +1,9 @@
+salt_versions = [
+  "2018.3.4",
+]
+
+repo_prefix = "repo/archive/saltstack/salt/linux/"
+
+salt_s3_endpoint = "https://s3.archive.repo.saltstack.com/"
+
+yum_prefix = "yum.defs/saltstack/salt/"

--- a/dev/salt-repo-archive/terragrunt.hcl
+++ b/dev/salt-repo-archive/terragrunt.hcl
@@ -1,0 +1,11 @@
+include {
+  path = find_in_parent_folders()
+}
+
+terraform {
+  source = "git::https://github.com/plus3it/salt-reposync.git//?ref=4.0.1"
+}
+
+dependencies {
+  paths = ["../files-repo"]
+}


### PR DESCRIPTION
Note the repo prefix: `repo/archive/saltstack/salt/linux/`. This introduces the `archive/` path to the repo baseurl. E.g.

```
baseurl=https://watchmaker.dev.cloudarmor.io/repo/archive/saltstack/salt/linux/python2/amazon/2/$basearch/archive/2018.3.4
```

This breaks yum repo definitions that point to `repo/saltstack/salt/linux/` and expect to find 2018.3.4 there, such as systems that have previously run watchmaker. However, the yum repo definitions that watchmaker installs, as provided by the salt-reposync project, _do_ ignore unavailable repos using `skip_if_unavailable=1`. So not expecting any complications from watchmaker-managed systems.

The yum prefix remains the same: `yum_prefix = yum.defs/saltstack/salt/`. This means the url remains the same for the yum repo file used by the watchmaker config. This preserves the watchmaker upgrade path for linux, from salt 2018.3.4 to 2019.2.5. Its _contents_ will change, to point at the new repo prefix, mentioned above. This way, new runs of watchmaker will get the new baseurl when using 2018.3.4, until we push the update to 2019.2.5.

For Windows, we do not have the abstraction of the yum repo file, so we must put the archived salt installer in the same location as before, or we break the upgrade path from 2018.3.4 to 2019.2.5.
