### PR TITLE
Bumps version to 1.1.2

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.1
+current_version = 1.1.2
 commit = True
 message = Bumps version to {new_version}
 tag = False


### PR DESCRIPTION
This releases the new salt-reposync behavior, to manage both the main and archive repos. Confirmed locally that the release pipeline is doing the right thing with the archive paths and the yum repo definitions.