### PR TITLE
Minimizes output to avoid travis-ci limits

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.4
+current_version = 1.1.5
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/Makefile
+++ b/Makefile
@@ -39,5 +39,5 @@ deploy/release: | guard/deploy guard/env/DEV_BUCKET
 	@echo "[$@]: Deploying 'release' pipeline!"
 	pipenv run terragrunt plan -out tfplan --terragrunt-working-dir release/bucket-list --terragrunt-source-update
 	pipenv run terragrunt apply tfplan --terragrunt-working-dir release/bucket-list
-	pipenv run terragrunt plan-all -out tfplan --terragrunt-working-dir release --terragrunt-source-update --terragrunt-exclude-dir bucket-list
-	pipenv run terragrunt apply-all tfplan --terragrunt-working-dir release --terragrunt-exclude-dir bucket-list
+	pipenv run terragrunt plan-all -out tfplan --terragrunt-working-dir release --terragrunt-source-update --terragrunt-exclude-dir bucket-list > /dev/null
+	pipenv run terragrunt apply-all tfplan --terragrunt-working-dir release --terragrunt-exclude-dir bucket-list > /dev/null


### PR DESCRIPTION
Turns out travis-ci has a ~4MB limit on the size of the output log.
When the output exceeds that, the job is cancelled. There is no
workaround, other than reducing the amount of output.

https://docs.travis-ci.com/user/common-build-problems/#log-length-exceeded

This patch suppresses only stdout in the release pipeline, where we've
experienced this problem. Output from the bucket-list is still provided,
as this will generally identify what items will be changing. The exception
is when the yum definition files change. Addressing that would require
larger changes to the pipeline. Prefer to see if this works for us,
first, before making larger changes.

Also, stderr is still output, so we will see the terragrunt output,
as well as any terraform errors if there are problems.