### PR TITLE
Update the terraform.tfvars with SCC v5.7.1

### DIFF
--- a/.bumpversion.cfg
+++ b/.bumpversion.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.2.2
+current_version = 1.2.3
 commit = True
 message = Bumps version to {new_version}
 tag = False

--- a/dev/files-repo/terraform.tfvars
+++ b/dev/files-repo/terraform.tfvars
@@ -18,10 +18,15 @@ uri_map = {
 
 
   # spawar scc
-  "s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.5_Windows_Setup.exe" = "spawar/scc/"
-  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.5.rhel7.x86_64.rpm"  = "spawar/scc/"
-  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.5.rhel8.x86_64.rpm"  = "spawar/scc/"
-  "s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.5"       = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.5_Windows_Setup.exe"   = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.5.rhel7.x86_64.rpm"    = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.5.rhel8.x86_64.rpm"    = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.5"         = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.x"         = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.7.1_Windows_Setup.exe" = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel7.x86_64.rpm"  = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel8.x86_64.rpm"  = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel9.x86_64.rpm"  = "spawar/scc/"
 }
 
 prefix = "repo/"


### PR DESCRIPTION
Added s3 urls for the wrangler-watchmaker update:

s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.x
s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.7.1_Windows_Setup.exe
s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel7.x86_64.rpm
s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel8.x86_64.rpm
s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel9.x86_64.rpm