### PR TITLE
Add SCC 5.9 bits

### DIFF
--- a/dev/files-repo/terraform.tfvars
+++ b/dev/files-repo/terraform.tfvars
@@ -27,9 +27,13 @@ uri_map = {
   "s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.5"         = "spawar/scc/"
   "s3://wrangler-watchmaker-filecache/spawar/scc/RPM-GPG-KEY-scc-5.x"         = "spawar/scc/"
   "s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.7.1_Windows_Setup.exe" = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/SCC_5.9_Windows_Setup.exe"   = "spawar/scc/"
   "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel7.x86_64.rpm"  = "spawar/scc/"
   "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel8.x86_64.rpm"  = "spawar/scc/"
   "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.7.1.rhel9.x86_64.rpm"  = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.9.rhel7.x86_64.rpm"    = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.9.rhel8.x86_64.rpm"    = "spawar/scc/"
+  "s3://wrangler-watchmaker-filecache/spawar/scc/scc-5.9.rhel9.x86_64.rpm"    = "spawar/scc/"
 }
 
 prefix = "repo/"


### PR DESCRIPTION
In order to support EL9, content for SCC 5.9 needs to be added. Also adding 5.9 bits for EL 7 & 8 and Windows since they're available. Leaving the 5.7.1 bits in place for backwards compatibility.